### PR TITLE
Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ server.py
 .vscode/
 s.py
 c.py
+/myyamlconf/

--- a/Algorithms/tf2algos/duelingdqn.py
+++ b/Algorithms/tf2algos/duelingdqn.py
@@ -134,11 +134,11 @@ class DDDQN(Policy):
                 next_max_action = tf.argmax(adv_next, axis=1, name='next_action_int')
                 next_max_action_one_hot = tf.one_hot(tf.squeeze(next_max_action), self.a_counts, 1., 0., dtype=tf.float32)
                 next_max_action_one_hot = tf.cast(next_max_action_one_hot, tf.float32)
-                v_next_target, adv_next_taeget = self.dueling_target_net(s_, visual_s_)
-                average_a_target_next = tf.reduce_mean(adv_next_taeget, axis=1, keepdims=True)
+                v_next_target, adv_next_target = self.dueling_target_net(s_, visual_s_)
+                average_a_target_next = tf.reduce_mean(adv_next_target, axis=1, keepdims=True)
                 q_eval = tf.reduce_sum(tf.multiply(v + adv - average_adv, a), axis=1, keepdims=True)
                 q_target_next_max = tf.reduce_sum(
-                    tf.multiply(v_next_target + adv_next_taeget - average_a_target_next, next_max_action_one_hot),
+                    tf.multiply(v_next_target + adv_next_target - average_a_target_next, next_max_action_one_hot),
                     axis=1, keepdims=True)
                 q_target = tf.stop_gradient(r + self.gamma * (1 - done) * q_target_next_max)
                 td_error = q_eval - q_target

--- a/Nn/tf2nn.py
+++ b/Nn/tf2nn.py
@@ -28,7 +28,7 @@ class mlp(Sequential):
             self.add(Dense(output_shape, out_activation))
 
 
-class mlp_witch_noisy(Sequential):
+class mlp_with_noisy(Sequential):
     def __init__(self, hidden_units, act_fn=activation_fn, output_shape=1, out_activation=None, out_layer=True):
         """
         inputs:
@@ -244,9 +244,9 @@ class critic_q_all(ImageNet):
 class critic_dueling(ImageNet):
     def __init__(self, vector_dim, visual_dim, output_shape, name, hidden_units):
         super().__init__(name=name, visual_dim=visual_dim)
-        self.share = mlp_witch_noisy(hidden_units['share'], out_layer=False)
-        self.v = mlp_witch_noisy(hidden_units['v'], output_shape=1, out_activation=None)
-        self.adv = mlp_witch_noisy(hidden_units['adv'], output_shape=output_shape, out_activation=None)
+        self.share = mlp_with_noisy(hidden_units['share'], out_layer=False)
+        self.v = mlp_with_noisy(hidden_units['v'], output_shape=1, out_activation=None)
+        self.adv = mlp_with_noisy(hidden_units['adv'], output_shape=output_shape, out_activation=None)
         self(tf.keras.Input(shape=vector_dim), tf.keras.Input(shape=visual_dim))
 
     def call(self, vector_input, visual_input):

--- a/config.py
+++ b/config.py
@@ -51,7 +51,7 @@ train_config = {
         'render': False,
         'render_episode': 50000,
         'render_mode': 'random_1', # first, last, [list], random_[num], or all.
-        'eval_while_train': False,
+        'eval_while_train': True,
         'max_eval_episode': 100,
     },
 


### PR DESCRIPTION
Hi!
You wrote:
"For all of these algorithms which implement based on tf2.0, you could change the layer from Dense to Noisy in tf2nn.py to implement noisy net for more exploration."

Maybe I didn’t understand correctly ...
I found an unused class Noisy, and TF 2 has its own implementation of "GaussianNoise". I tried using it in "class mlp_with_noisy (Sequential):"

I tested the dddqn algorithm:
python run.py --gym -a dddqn -c myyamlconf\cart.yaml -n train_using_gym -g --gym-env CartPole-v1 --render-episode 100 --gym-agents 4

Config:
assign_interval: 1000
batch_size: 256
buffer_size: 200000
eps_final: 0.01
eps_init: 1
eps_mid: 0.2
gamma: 0.99
hidden_units:
  adv:
  - 16
  share:
  - 8
  v:
  - 4
init2mid_annealing_episode: 50
lr: 0.001
n_step: false
use_priority: false
Result:
Episode: 138 | step: 500 | last_done_step 500 | rewards: [500. 66. 69. 500.]
------------------------------------------- Evaluate episode: 138 --- -----------------------------------------------
evaluate number: 100 | average step: 475 | average reward: 475.85 | SOLVED: True
-------------------------------------------------- -------------------------------------------------- ------------------------

Without  use mlp_with_noisy:
Episode: 162 | step:  500 | last_done_step  500 | rewards: [151. 124. 500. 244.]
-------------------------------------------Evaluate episode: 162--------------------------------------------------
evaluate number: 100 | average step: 500 | average reward: 500.0 | SOLVED: True
----------------------------------------------------------------------------------------------------------------------------
