### PR TITLE
Change of approach to data storage. AC, A2C changed

### DIFF
--- a/Algorithms/tf2algos/a2c.py
+++ b/Algorithms/tf2algos/a2c.py
@@ -100,10 +100,10 @@ class A2C(Policy):
 
     def get_sample_data(self, index):
         i_data = self.data.iloc[index:index + self.batch_size]
-        s = np.vstack(i_data.s.values)
-        visual_s = np.vstack(i_data.visual_s.values)
-        a = np.vstack(i_data.a.values)
-        dc_r = np.vstack(i_data.discounted_reward.values).reshape(-1, 1)
+        s = np.vstack(i_data.s.values).astype('float32')
+        visual_s = np.vstack(i_data.visual_s.values).astype('float32')
+        a = np.vstack(i_data.a.values).astype('float32')
+        dc_r = np.vstack(i_data.discounted_reward.values).reshape(-1, 1).astype('float32')
         return s, visual_s, a, dc_r
 
     def learn(self, **kwargs):

--- a/Algorithms/tf2algos/ac.py
+++ b/Algorithms/tf2algos/ac.py
@@ -99,8 +99,8 @@ class AC(Policy):
         if not self.action_type == 'continuous':
             a = sth.action_index2one_hot(a, self.a_dim_or_list)
         old_log_prob = self._get_log_prob(s, visual_s, a).numpy()
-        self.data.add(s.astype(np.float32), visual_s.astype(np.float32), a.astype(np.float32), old_log_prob.astype(np.float32),
-                      r[:, np.newaxis].astype(np.float32), s_.astype(np.float32), visual_s_.astype(np.float32), done[:, np.newaxis].astype(np.float32))
+        self.data.add(s, visual_s, a, old_log_prob,
+                      r[:, np.newaxis], s_, visual_s_, done[:, np.newaxis])
 
     @tf.function
     def _get_log_prob(self, s, visual_s, a):
@@ -123,8 +123,8 @@ class AC(Policy):
             old_log_prob = np.ones_like(r)
             if not self.action_type == 'continuous':
                 a = sth.action_index2one_hot(a, self.a_dim_or_list)
-            self.data.add(s.astype(np.float32), visual_s.astype(np.float32), a.astype(np.float32), old_log_prob[:, np.newaxis].astype(
-                np.float32), r[:, np.newaxis].astype(np.float32), s_.astype(np.float32), visual_s_.astype(np.float32), done[:, np.newaxis].astype(np.float32))
+            self.data.add(s, visual_s, a, old_log_prob[:, np.newaxis],
+                          r[:, np.newaxis], s_, visual_s_, done[:, np.newaxis])
 
     def learn(self, **kwargs):
         self.episode = kwargs['episode']
@@ -132,7 +132,12 @@ class AC(Policy):
             s, visual_s, a, old_log_prob, r, s_, visual_s_, done = self.data.sample()
             if self.use_priority:
                 self.IS_w = self.data.get_IS_w()
-            td_error, summaries = self.train(s, visual_s, a, r, s_, visual_s_, done, old_log_prob)
+            # td_error, summaries = self.train(s.astype(np.float32), visual_s.astype(np.float32), a.astype(np.float32),
+            #                                  r.astype(np.float32), s_.astype(np.float32), visual_s_.astype(np.float32),
+            #                                 done.astype(np.float32), old_log_prob.astype(np.float32))
+            td_error, summaries = self.train(s, visual_s, a,
+                                             r, s_, visual_s_,
+                                             done, old_log_prob)
             if self.use_priority:
                 self.data.update(td_error, self.episode)
             summaries.update(dict([
@@ -144,6 +149,14 @@ class AC(Policy):
     @tf.function(experimental_relax_shapes=True)
     def train(self, s, visual_s, a, r, s_, visual_s_, done, old_log_prob):
         with tf.device(self.device):
+            s = tf.cast(s, tf.float32)
+            visual_s = tf.cast(visual_s, tf.float32)
+            a = tf.cast(a, tf.float32)
+            r = tf.cast(r, tf.float32)
+            s_ = tf.cast(s_, tf.float32)
+            visual_s_ = tf.cast(visual_s_, tf.float32)
+            done = tf.cast(done, tf.float32)
+            old_log_prob = tf.cast(old_log_prob, tf.float32)
             with tf.GradientTape() as tape:
                 if self.action_type == 'continuous':
                     next_mu = self.actor_net(s_, visual_s_)
@@ -198,6 +211,14 @@ class AC(Policy):
     @tf.function(experimental_relax_shapes=True)
     def train_persistent(self, s, visual_s, a, r, s_, visual_s_, done, old_log_prob):
         with tf.device(self.device):
+            s = tf.cast(s, tf.float32)
+            visual_s = tf.cast(visual_s, tf.float32)
+            a = tf.cast(a, tf.float32)
+            r = tf.cast(r, tf.float32)
+            s_ = tf.cast(s_, tf.float32)
+            visual_s_ = tf.cast(visual_s_, tf.float32)
+            done = tf.cast(done, tf.float32)
+            old_log_prob = tf.cast(old_log_prob, tf.float32)
             with tf.GradientTape(persistent=True) as tape:
                 if self.action_type == 'continuous':
                     next_mu = self.actor_net(s_, visual_s_)

--- a/Algorithms/tf2algos/policy.py
+++ b/Algorithms/tf2algos/policy.py
@@ -100,13 +100,13 @@ class Policy(Base):
         if not self.action_type == 'continuous':
             a = sth.action_index2one_hot(a, self.a_dim_or_list)
         self.data = self.data.append({
-            's': s.astype(np.float32),
-            'visual_s': visual_s.astype(np.float32),
-            'a': a.astype(np.float32),
-            'r': r.astype(np.float32),
-            's_': s_.astype(np.float32),
-            'visual_s_': visual_s_.astype(np.float32),
-            'done': done.astype(np.float32)
+            's': s,
+            'visual_s': visual_s,
+            'a': a,
+            'r': r,
+            's_': s_,
+            'visual_s_': visual_s_,
+            'done': done
         }, ignore_index=True)
 
     def off_store(self, s, visual_s, a, r, s_, visual_s_, done):
@@ -119,13 +119,13 @@ class Policy(Base):
         if not self.action_type == 'continuous':
             a = sth.action_index2one_hot(a, self.a_dim_or_list)
         self.data.add(
-            s.astype(np.float32),
-            visual_s.astype(np.float32),
-            a.astype(np.float32),
-            r[:, np.newaxis].astype(np.float32),
-            s_.astype(np.float32),
-            visual_s_.astype(np.float32),
-            done[:, np.newaxis].astype(np.float32)
+            s,
+            visual_s,
+            a,
+            r[:, np.newaxis],
+            s_,
+            visual_s_,
+            done[:, np.newaxis]
         )
 
     def no_op_store(self, s, visual_s, a, r, s_, visual_s_, done):
@@ -136,13 +136,13 @@ class Policy(Base):
             if not self.action_type == 'continuous':
                 a = sth.action_index2one_hot(a, self.a_dim_or_list)
             self.data.add(
-                s.astype(np.float32),
-                visual_s.astype(np.float32),
-                a.astype(np.float32),
-                r[:, np.newaxis].astype(np.float32),
-                s_.astype(np.float32),
-                visual_s_.astype(np.float32),
-                done[:, np.newaxis].astype(np.float32)
+                s,
+                visual_s,
+                a,
+                r[:, np.newaxis],
+                s_,
+                visual_s_,
+                done[:, np.newaxis]
             )
 
     def clear(self):

--- a/Nn/tf2nn.py
+++ b/Nn/tf2nn.py
@@ -120,7 +120,8 @@ class ImageNet(tf.keras.Model):
 
     def call(self, vector_input, visual_input):
         if self.build_visual:
-            features = self.conv1(visual_input)
+            features = visual_input/255
+            features = self.conv1(features)
             features = self.conv2(features)
             features = self.conv3(features)
             features = self.flatten(features)

--- a/gym_wrapper.py
+++ b/gym_wrapper.py
@@ -107,7 +107,7 @@ class gym_envs(object):
             threading.Thread.join(th)
         obs = np.array([threadpool[i].get_result() for i in range(self.n)])
         obs = self._maybe_one_hot(obs)
-        return obs.astype(np.float32)
+        return obs
 
         # if self.obs_type == 'visual':
         #     return np.array([threadpool[i].get_result()[np.newaxis, :] for i in range(self.n)]).astype(np.float32)
@@ -140,7 +140,7 @@ class gym_envs(object):
         obs, reward, done, info = [np.array(e) for e in zip(*results)]
         obs = self._maybe_one_hot(obs)
         self.dones_index = np.where(done)[0]
-        return obs.astype(np.float32), reward.astype(np.float32), done, info
+        return obs, reward, done, info
 
     def partial_reset(self):
         threadpool = []
@@ -153,7 +153,7 @@ class gym_envs(object):
             threading.Thread.join(th)
         obs = np.array([threadpool[i].get_result() for i in range(self.dones_index.shape[0])])
         obs = self._maybe_one_hot(obs, is_partial=True)
-        return obs.astype(np.float32)
+        return obs
 
         # if self.obs_type == 'visual':
         #     return np.array([threadpool[i].get_result()[np.newaxis, :] for i in range(self.dones_index.shape[0])]).astype(np.float32)


### PR DESCRIPTION
Hello!
Again, I took the liberty of making changes to the code without approval.
For optimization, I tried to change the data storage approach:
1. Data is stored in the form in which it is transmitted by the environment.
2. Conversion to float32 takes place before they are sent to the model or in the tf-function itself.
 I tried on AC, A2C Algorithms .. It seems to work and requires much less RAM.
I’ll test it at home on a more powerful PC on Atari Env.
As a suggestion, I have the following:
go completely to type float64;
try to perform data conversion for all algorithms only in tf-functions.